### PR TITLE
Improve stability 

### DIFF
--- a/packages/frameworks-astro/index.ts
+++ b/packages/frameworks-astro/index.ts
@@ -72,15 +72,13 @@ async function handler(
 export function AstroAuth(config: AstroAuthConfig) {
   const { prefix = "/api/auth", ...authConfig } = config
   // @ts-expect-error import.meta.env is used by Astro
-  authConfig.secret ??= import.meta.env.AUTH_SECRET
-  // @ts-expect-error
+  const { AUTH_SECRET, AUTH_TRUST_HOST, VERCEL, NODE_ENV } = import.meta.env
+
+  authConfig.secret ??= AUTH_SECRET
   authConfig.trustHost ??= !!(
-    // @ts-expect-error
-    import.meta.env.AUTH_TRUST_HOST ??
-    // @ts-expect-error
-    import.meta.env.VERCEL ??
-    // @ts-expect-error
-    import.meta.env.NODE_ENV !== "production"
+    AUTH_TRUST_HOST ??
+    VERCEL ??
+    NODE_ENV !== "production"
   )
 
   return {
@@ -97,16 +95,9 @@ export async function getSession(
   req: Request,
   options: AuthConfig
 ): Promise<Session | null> {
-  // @ts-ignore import.meta.env is used by Astro
+  // @ts-expect-error import.meta.env is used by Astro
   options.secret ??= import.meta.env.AUTH_SECRET
-  options.trustHost ??= !!(
-    // @ts-expect-error
-    import.meta.env.AUTH_TRUST_HOST ??
-    // @ts-expect-error
-    import.meta.env.VERCEL ??
-    // @ts-expect-error
-    import.meta.env.NODE_ENV !== "production"
-  )
+  options.trustHost ??= true
 
   const url = new URL("/api/auth/session", req.url)
   const response = await Auth(

--- a/packages/frameworks-astro/package.json
+++ b/packages/frameworks-astro/package.json
@@ -18,6 +18,7 @@
     "patch": "npm version patch --no-git-tag-version"
   },
   "devDependencies": {
+    "@types/cookie": "0.5.1",
     "@types/set-cookie-parser": "^2.4.2",
     "astro": "^2.0.0-beta.2",
     "next-auth": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,7 @@ importers:
   packages/frameworks-astro:
     specifiers:
       '@auth/core': workspace:*
+      '@types/cookie': 0.5.1
       '@types/set-cookie-parser': ^2.4.2
       astro: ^2.0.0-beta.2
       next-auth: workspace:*
@@ -544,6 +545,7 @@ importers:
       '@auth/core': link:../core
       set-cookie-parser: 2.5.1
     devDependencies:
+      '@types/cookie': 0.5.1
       '@types/set-cookie-parser': 2.4.2
       astro: 2.0.0-beta.2
       next-auth: link:../next-auth


### PR DESCRIPTION
Just a small PR to improve readability and such.
I removed the trustAuth by env vars for the getSession method and hardcoded as true. I guess this is the expected behavior.
Also I didn´t like all the comments so I put the vars in one line.